### PR TITLE
fix requirements.ansible.yml versions

### DIFF
--- a/requirements.ansible.yml
+++ b/requirements.ansible.yml
@@ -1,8 +1,8 @@
 roles:
   - name: dev-sec.os-hardening
-    version: v6.2.0
+    version: 6.2.0
   - name: dev-sec.ssh-hardening
-    version: v9.7.0
+    version: 9.7.0
   - name: matthiaslohr.hvswitch_k8s
     version: v1.0.0
 


### PR DESCRIPTION
I had to remove the `v` from the 2 dev-sec requirements in order for the ansible-galaxy command to run.  I'm not sure if this is specific to my local environment.

Error message:

```
[WARNING]: - dev-sec.os-hardening was NOT installed successfully: - the specified version (v6.2.0) of dev-sec.os-hardening was not found in the list of available versions
[...]
```

My environment:

```
ansible-galaxy 2.9.12
  config file = /Users/f/bare-metal-cluster-manager/ansible.cfg
  configured module search path = ['/Users/f/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.9/site-packages/ansible
  executable location = /usr/local/bin/ansible-galaxy
  python version = 3.9.4 (default, Apr  5 2021, 01:50:46) [Clang 12.0.0 (clang-1200.0.32.29)]
```